### PR TITLE
Jekyll fixes + testing changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: ruby
 rvm:
 - 2.3.3
+addons:
+  apt:
+    packages:
+    - libcurl4-openssl-dev # Required to avoid TLS errors
 
 script:
   - set -e # halt script on error

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 Wir freuen uns, dass du dir überlegst, dich an diesem Repository zu beteiligen.
 Zunächst solltest du wissen, dass du, wenn du zu diesem Repository beitragen
 möchtest, unseren
-[Lizenzbestimmungen](https://github.com/fsi-tue/skripte/blob/master/LICENSE)
+[Lizenzbestimmungen](/LICENSE.txt)
 zustimmen musst. Wir verwenden in diesem Repository eine
 [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) Lizenz, was bedeutet,
 dass du den Inhalt beliebig teilen und verändern kannst unter der Bedingung,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,20 @@ Falls du bereits mit Git vertraut bist, befolge die folgenden Schritte:
    ```
 3. Mache deine Änderungen lokal.
 4. Committe deine Änderungen und push sie auf deinen Fork.
-5. Erstelle einen neuen Pull Request für deine Änderungen.
+5. Optional: Am besten prüfst du deine Änderungen ggf. kurz (s. unten).
+6. Erstelle einen neuen Pull Request für deine Änderungen.
 
+
+### Testing your changes
+
+Je nach Komplexität deiner Änderung kannst du dir diesen Schritt auch sparen.
+Bei normalen Änderungen sollte es reichen, wenn du dir kurz über GitHub die
+Vorschau anzeigen lässt (du kannst den GitHub flavored Markdown code natürlich
+auch lokal, z. B. mit `Pandoc` rendern). Bei komplexeren Änderungen bietet es
+sich an die GitHub Pages auf dem eigenen Fork zu aktivieren: Settings ->
+GitHub Pages -> Source -> master branch -> Save. Nach ein paar Sekunden kannst
+du deine Seite über https://yourname.github.io/skripte/ aufrufen. Alternativ
+kannst du Jekyll auch lokal ausführen (advanced).
 
 ### Continuous Integration
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,9 @@ ruby RUBY_VERSION
 # This is the gem used to use GitHub's defaults
 gem 'github-pages', group: :jekyll_plugins
 
+# For GitHub flavored emoji support
+gem 'jemoji'
+
 # This is the gem used to test the output html
 gem "html-proofer"
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,4 @@
 theme: jekyll-theme-minimal
 include: [CONTRIBUTING.md]
+plugins:
+  - jemoji

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,2 @@
 theme: jekyll-theme-minimal
+include: [CONTRIBUTING.md]


### PR DESCRIPTION
Jekyll hat die CONTRIBUTING.md nicht gerendert: https://fsi-tue.github.io/skripte/CONTRIBUTING.md bzw. https://fsi-tue.github.io/skripte/CONTRIBUTING.html (404). Jetzt sieht es so aus: https://primeos.github.io/skripte/CONTRIBUTING.html. Ich hab auch gleich noch den Lizenz-Link gefixt und kurz dokumentiert, wie man die eigenen Änderungen testen kann (falls das jemand machen will).

Update: Emoji support... https://primeos.github.io/skripte/
Update2: Travis CI build gefixt (aber kp warum das plötzlich nicht mehr ging, evtl. neue container version / upgrades)